### PR TITLE
docs: add cloud connectivity setup guide (GCP VPN, VPC connector, SQL Server)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ Thumbs.db
 accuracy_report.json
 
 # Docs (kept local, not pushed to GitHub)
-docs/
+# docs/ is tracked — do not add to gitignore
 google-mcp/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,224 @@
+# Architecture & Tooling Reference
+
+## System Overview
+
+This project implements a multi-agent Retrieval-Augmented Generation (RAG) system built on Google's Agent Development Kit (ADK). It combines two retrieval strategies under a single routing layer:
+
+- **Text-to-SQL** for structured data queries against PostgreSQL
+- **Vertex AI RAG Engine** for unstructured document search
+
+The system runs on Google Cloud Run with a custom web UI.
+
+## Architecture Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Browser                                                         │
+│  Custom UI (index.html + app.js + styles.css)                   │
+│  Hosted on Cloud Run (agentic-rag-ui)                           │
+└──────────────┬───────────────────────────────────────────────────┘
+               │  /api/*  (same-origin)
+               ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Nginx Reverse Proxy  (Cloud Run — port 8080)                   │
+│  • Static files at /                                             │
+│  • Proxies /api/* → ADK backend (no CORS needed)                │
+│  • SSE streaming support                                        │
+└──────────────┬───────────────────────────────────────────────────┘
+               │  HTTPS
+               ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  ADK Backend  (Cloud Run — agentic-rag-chat)                    │
+│  google-adk → FastAPI with SSE streaming                        │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │         root_agent (agentic_rag_router)                    │  │
+│  │         LlmAgent — Gemini 2.5 Flash                        │  │
+│  │         Role: Supervisor / Intent Router                   │  │
+│  │                                                            │  │
+│  │   Delegates to sub-agents via transfer_to_agent            │  │
+│  │         ┌──────────────┬──────────────────┐                │  │
+│  │         ▼              ▼                  │                │  │
+│  │  ┌─────────────┐ ┌──────────────┐         │                │  │
+│  │  │ database_   │ │  rag_agent   │         │                │  │
+│  │  │   agent     │ │              │         │                │  │
+│  │  │             │ │  Tool:       │         │                │  │
+│  │  │ Tools:      │ │  • retrieve_ │         │                │  │
+│  │  │ • get_      │ │    documents │         │                │  │
+│  │  │   schema_   │ │              │         │                │  │
+│  │  │   metadata  │ └──────┬───────┘         │                │  │
+│  │  │ • run_      │        │                 │                │  │
+│  │  │   readonly_ │        ▼                 │                │  │
+│  │  │   sql       │  Vertex AI RAG Engine    │                │  │
+│  │  └──────┬──────┘  (managed corpus)        │                │  │
+│  │         │                                 │                │  │
+│  └─────────┼─────────────────────────────────┘                │  │
+│            │                                                    │
+│    ┌───────▼────────┐    ┌──────────────┐                      │
+│    │ SQL Guardrails  │    │ PII Masker   │                      │
+│    │ • SELECT only   │    │ • regex      │                      │
+│    │ • blocked DML   │    │ • Presidio   │                      │
+│    │ • LIMIT inject  │    │   (optional) │                      │
+│    │ • timeout       │    │              │                      │
+│    │ • table allow   │    └──────┬───────┘                     │
+│    └───────┬─────────┘           │                             │
+│            │                     │ masks query results          │
+│            ▼                     │                              │
+│    ┌───────────────┐◄────────────┘                             │
+│    │  pg8000        │                                           │
+│    │  (PostgreSQL)  │                                           │
+│    └───────┬────────┘                                           │
+└────────────┼────────────────────────────────────────────────────┘
+             │  Cloud SQL Auth Proxy
+             ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Cloud SQL PostgreSQL (private IP)                               │
+│  Tables: customers, orders, order_items, products               │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Agent Design
+
+### Router Agent (`agentic_rag_router`)
+
+The entry point. Uses Gemini to classify user intent and delegates to the appropriate specialist. It never answers questions directly — it always routes.
+
+**Routing rules (LLM-driven, not heuristic):**
+- Data / numbers / SQL / analytics → `database_agent`
+- Policies / documents / contracts / guidelines → `rag_agent`
+
+### Database Agent (`database_agent`)
+
+Handles structured data questions using dynamic Text-to-SQL:
+
+1. Calls `get_schema_metadata()` to discover tables and columns
+2. Writes a read-only SQL query based on the schema
+3. Calls `run_readonly_sql(sql)` to execute with guardrails
+4. If execution fails, reads the error, fixes the SQL, and retries
+
+### RAG Agent (`rag_agent`)
+
+Handles unstructured document questions:
+
+1. Calls `retrieve_documents(query)` to search the Vertex AI RAG corpus
+2. Synthesizes retrieved chunks into a coherent answer
+3. Cites source documents
+
+## Tools (Function Definitions)
+
+### `get_schema_metadata()`
+
+Queries `information_schema.columns` for allowed tables and returns table names, column names, and data types. Gives the LLM accurate schema context before it writes SQL.
+
+### `run_readonly_sql(sql: str)`
+
+Executes LLM-generated SQL with these safety layers:
+
+| Guardrail | Description |
+|-----------|-------------|
+| Read-only check | Only `SELECT` / `WITH` statements allowed |
+| Keyword blocklist | Rejects `INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `CREATE`, `TRUNCATE`, `GRANT`, `REVOKE`, `MERGE`, `CALL`, `EXECUTE`, `COPY` |
+| Multi-statement block | Rejects queries with `;` in the middle |
+| System schema block | Blocks `information_schema.*` and `pg_catalog.*` |
+| Auto LIMIT | Appends `LIMIT {max_rows}` when no limit clause is present |
+| Statement timeout | Sets `statement_timeout` on the connection (default 15s) |
+| Table allowlist | Only tables in `TEXT_TO_SQL_ALLOWED_TABLES` are visible via schema metadata |
+
+### `retrieve_documents(query: str)`
+
+Calls `vertexai.preview.rag.retrieval_query()` to semantic-search a managed RAG corpus. Returns top-5 document chunks with source URIs and relevance scores. Controlled by `VERTEX_RAG_CORPUS` env var.
+
+## PII Masking
+
+Applied to every SQL result row before it reaches the LLM. Two modes:
+
+- **Regex (default)** — catches names (`FirstName LastName` → `PERSON_1`), emails → `EMAIL_1`, SSNs → `SSN_1`. Uses consistent tokenization so the same entity always maps to the same placeholder.
+- **Presidio (optional)** — Microsoft's NER-based PII engine. Enable with `PII_USE_PRESIDIO=true`.
+
+Controlled by `PII_MASKING_ENABLED`, `PII_USE_PRESIDIO`, `PII_DEFAULT_RULES`.
+
+## Credential Management
+
+`_resolve_db_password()` follows a two-step resolution:
+
+1. If `DB_PASSWORD_SECRET` is set (format: `projects/PROJECT/secrets/NAME/versions/latest`), loads the password from Google Secret Manager
+2. Falls back to `DB_PASSWORD` env var with a warning log
+
+## Database Connectivity
+
+pg8000 (pure-Python PostgreSQL driver) with multi-fallback connection:
+
+1. TCP to `127.0.0.1:5432` (Cloud SQL Auth Proxy sidecar)
+2. Unix socket at `/cloudsql/{instance_connection_name}`
+3. Unix socket with `.s.PGSQL.5432` suffix
+
+## Technology Stack
+
+| Component | Technology | Version |
+|-----------|-----------|---------|
+| Agent framework | Google ADK | 1.5.0 |
+| LLM | Gemini 2.5 Flash | latest |
+| Backend runtime | FastAPI (via ADK) | — |
+| PostgreSQL driver | pg8000 | ≥ 1.31.2 |
+| Document retrieval | Vertex AI RAG Engine | via google-cloud-aiplatform ≥ 1.74.0 |
+| PII detection | Regex + Presidio (optional) | — |
+| Settings | Pydantic Settings | ≥ 2.4.0 |
+| Secret management | Google Secret Manager | optional |
+| Hosting | Google Cloud Run | 2 services |
+| UI proxy | Nginx | 1.27-alpine |
+| Database | Cloud SQL PostgreSQL 15 | — |
+
+## Deployment Topology
+
+Two Cloud Run services:
+
+| Service | Role | Image |
+|---------|------|-------|
+| `agentic-rag-chat` | ADK backend (FastAPI + SSE) | Auto-built by `adk deploy cloud_run` |
+| `agentic-rag-ui` | Custom UI + nginx reverse proxy | `nginx:1.27-alpine` |
+
+The nginx proxy serves the static UI at `/` and forwards `/api/*` to the backend, eliminating CORS requirements.
+
+## Request Flow
+
+```
+User: "What is the total revenue from all orders?"
+
+1. Browser → POST /api/run_sse → nginx → ADK backend
+2. root_agent (Gemini) → classifies as data question → transfer_to_agent(database_agent)
+3. database_agent (Gemini) → calls get_schema_metadata()
+   → receives 4 tables, 19 columns
+4. database_agent (Gemini) → generates SQL → calls run_readonly_sql("SELECT SUM(total_amount) FROM orders")
+   → guardrail validation passes
+   → LIMIT 200 appended
+   → pg8000 executes → [{total: 13082.0}]
+   → PII masking applied (no PII in numeric data, passes through)
+5. database_agent (Gemini) → "The total revenue is $13,082."
+6. SSE streams all events → UI renders answer + trace panel
+```
+
+## Environment Variables
+
+See `.env.example` for the full list. Key groups:
+
+- **Cloud / Auth**: `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_GENAI_USE_VERTEXAI`
+- **Model**: `AGENT_MODEL`
+- **Database**: `DB_INSTANCE_CONNECTION_NAME`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_PASSWORD_SECRET`
+- **Guardrails**: `TEXT_TO_SQL_ALLOWED_TABLES`, `TEXT_TO_SQL_MAX_ROWS`, `TEXT_TO_SQL_QUERY_TIMEOUT_MS`
+- **PII**: `PII_MASKING_ENABLED`, `PII_USE_PRESIDIO`, `PII_DEFAULT_RULES`
+- **RAG**: `VERTEX_RAG_CORPUS`
+- **Tenant** (future): `TENANT_CONFIG_USE_FIRESTORE`, `TENANT_DEFAULT_DB_TYPE`
+
+## Accuracy
+
+Tested with 12 query types (counts, aggregations, filters, JOINs, GROUP BY, subqueries, date range, DISTINCT). Results:
+
+- **SQL execution success**: 12/12 (100%)
+- **Answer accuracy**: 11/12 (92%)
+- The single miss was a session-context issue in a long multi-turn conversation, not a SQL generation failure
+
+Accuracy stays high because:
+1. Small, clean schema (4 tables, 19 columns) fits easily in LLM context
+2. Schema-first workflow ensures the LLM sees real column names before writing SQL
+3. Retry-on-error instruction lets the agent self-correct
+4. Guardrails catch dangerous operations before execution

--- a/docs/client-network-setup.md
+++ b/docs/client-network-setup.md
@@ -1,0 +1,151 @@
+# Secure Database Tunnel Setup — IT Instructions for Youngsinc
+
+## What This Does
+
+This creates a **secure, encrypted, outbound-only tunnel** from your network to our cloud.  
+Your SQL Server (`10.0.0.22:1433`) becomes accessible to our application hosted on Google Cloud.
+
+**No inbound firewall rules needed. No VPN service. No ports opened on your router.**  
+One small background process on any always-on Windows/Linux machine inside your network.
+
+---
+
+## What You Need
+
+| Requirement | Details |
+|-------------|---------|
+| A Windows or Linux machine | Any PC/server that is **always on** and has network access to `10.0.0.22` |
+| Internet access from that machine | Outbound TCP port **9090** must be allowed (most corporate firewalls allow this by default) |
+| Admin rights on that machine | Just to run the process (or install as a service) |
+
+---
+
+## Step-by-Step Setup
+
+### Step 1 — Download `chisel` (one binary, ~8 MB, no install needed)
+
+**On Windows:**
+1. Go to: https://github.com/jpillora/chisel/releases/latest
+2. Download: `chisel_X.X.X_windows_amd64.gz`
+3. Extract the `.gz` file (use 7-Zip or WinRAR) → you get `chisel.exe`
+4. Move `chisel.exe` to `C:\chisel\chisel.exe`
+
+**On Linux:**
+```bash
+curl -Lo chisel.gz https://github.com/jpillora/chisel/releases/latest/download/chisel_1.10.1_linux_amd64.gz
+gunzip chisel.gz
+chmod +x chisel
+sudo mv chisel /usr/local/bin/chisel
+```
+
+---
+
+### Step 2 — Run the tunnel (one command)
+
+We will provide you with our **cloud server IP** once set up on our end. Replace `CLOUD_IP` below.
+
+**On Windows** — open Command Prompt as Administrator:
+```
+C:\chisel\chisel.exe client CLOUD_IP:9090 R:1433:10.0.0.22:1433
+```
+
+**On Linux:**
+```bash
+chisel client CLOUD_IP:9090 R:1433:10.0.0.22:1433
+```
+
+You should see output like:
+```
+2026/03/01 10:00:00 client: Connected (Latency 45ms)
+```
+
+That's it. The tunnel is active.
+
+---
+
+### Step 3 — Keep it running (set up as a background service)
+
+#### Windows — Install as a Windows Service (runs automatically on boot)
+
+1. Download NSSM (Non-Sucking Service Manager): https://nssm.cc/download  
+   Extract `nssm.exe` to `C:\chisel\`
+
+2. Open Command Prompt **as Administrator** and run:
+```
+C:\chisel\nssm.exe install ChiselTunnel "C:\chisel\chisel.exe" "client CLOUD_IP:9090 R:1433:10.0.0.22:1433"
+C:\chisel\nssm.exe set ChiselTunnel DisplayName "Chisel DB Tunnel"
+C:\chisel\nssm.exe set ChiselTunnel Description "Secure outbound tunnel to cloud application"
+C:\chisel\nssm.exe set ChiselTunnel Start SERVICE_AUTO_START
+C:\chisel\nssm.exe start ChiselTunnel
+```
+
+3. Verify it's running:
+```
+sc query ChiselTunnel
+```
+
+#### Linux — Install as a systemd service
+
+Create `/etc/systemd/system/chisel-tunnel.service`:
+```ini
+[Unit]
+Description=Chisel DB Tunnel
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/chisel client CLOUD_IP:9090 R:1433:10.0.0.22:1433
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then enable and start:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable chisel-tunnel
+sudo systemctl start chisel-tunnel
+sudo systemctl status chisel-tunnel
+```
+
+---
+
+## Firewall / Security Notes for Your IT Team
+
+| Direction | Protocol | Port | Destination | Required? |
+|-----------|----------|------|-------------|-----------|
+| **Outbound** | TCP | 9090 | `CLOUD_IP` | ✅ Yes — this is the only requirement |
+| Inbound | Any | Any | — | ❌ No changes needed |
+| Router port forward | Any | Any | — | ❌ Not needed |
+
+**Security properties:**
+- All traffic is **TLS-encrypted** (same encryption as HTTPS)
+- Connection is **initiated from inside your network** — we cannot connect to you unless your process is running
+- You can **stop the service any time** to immediately cut off access
+- No credentials are stored on the tunnel machine — it only forwards TCP connections
+
+---
+
+## Connectivity Test
+
+Once the service is running, send us a message and we will confirm connectivity from our cloud to `10.0.0.22:1433` within a few minutes.
+
+If there's a connection issue, check:
+1. The chisel process is running (Task Manager → Services on Windows, `systemctl status` on Linux)
+2. The machine running chisel can reach `10.0.0.22:1433` (test: `telnet 10.0.0.22 1433` or `Test-NetConnection -ComputerName 10.0.0.22 -Port 1433` on PowerShell)
+3. Outbound TCP port 9090 is not blocked by your corporate firewall
+
+---
+
+## What We Will Provide
+
+Before you start Step 2, we will send you:
+- `CLOUD_IP` — the IP address of our cloud relay server
+- Confirmation that the server is ready to accept your connection
+
+---
+
+## Questions?
+
+Contact: [your name / email here]

--- a/docs/cloud-connectivity-setup.md
+++ b/docs/cloud-connectivity-setup.md
@@ -1,0 +1,475 @@
+# Cloud Connectivity Setup — GCP VPN, VPC Connector & SQL Server
+
+## Table of Contents
+1. [Architecture Overview](#architecture-overview)
+2. [Prerequisites](#prerequisites)
+3. [Step 1 — Reserve a Static External IP](#step-1--reserve-a-static-external-ip)
+4. [Step 2 — Create the Classic VPN Gateway](#step-2--create-the-classic-vpn-gateway)
+5. [Step 3 — Create the VPN Tunnel (IKEv2)](#step-3--create-the-vpn-tunnel-ikev2)
+6. [Step 4 — Add a Route for the Client Subnet](#step-4--add-a-route-for-the-client-subnet)
+7. [Step 5 — Create Firewall Rules](#step-5--create-firewall-rules)
+8. [Step 6 — Create a Serverless VPC Access Connector](#step-6--create-a-serverless-vpc-access-connector)
+9. [Step 7 — Configure Cloud Run to Use the Connector](#step-7--configure-cloud-run-to-use-the-connector)
+10. [Step 8 — Cloud SQL (PostgreSQL)](#step-8--cloud-sql-postgresql)
+11. [Step 9 — Secret Manager for Credentials](#step-9--secret-manager-for-credentials)
+12. [Local Dev — Docker IKEv2 Tunnel](#local-dev--docker-ikev2-tunnel)
+13. [Security Assessment](#security-assessment)
+14. [Troubleshooting Reference](#troubleshooting-reference)
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Google Cloud (us-central1)                                         │
+│                                                                     │
+│  ┌───────────────┐     VPC Connector       ┌────────────────────┐  │
+│  │  Cloud Run    │ ──────────────────────► │  default VPC       │  │
+│  │  agentic-rag  │   youngsinc-connector    │  172.16.0.0/28     │  │
+│  └───────────────┘   (serverless egress)   └────────┬───────────┘  │
+│                                                     │              │
+│                                            ┌────────▼───────────┐  │
+│                                            │  Classic VPN GW    │  │
+│                                            │  youngsinc-vpn-gw  │  │
+│                                            │  IP: 34.10.184.224 │  │
+│                                            └────────┬───────────┘  │
+└─────────────────────────────────────────────────────┼─────────────┘
+                                                      │ IKEv2 IPSec
+                                                      │ AES-256-GCM
+                                                      │ SHA-512
+                                          ┌───────────▼────────────┐
+                                          │  Youngsinc HQ VPN GW   │
+                                          │  72.240.11.135         │
+                                          │  remote.youngsinc.com  │
+                                          └───────────┬────────────┘
+                                                      │ LAN: 10.0.0.0/16
+                                          ┌───────────▼────────────┐
+                                          │  YISBeta SQL Server    │
+                                          │  10.0.0.22:1433        │
+                                          └────────────────────────┘
+
+  Cloud Run also connects to Cloud SQL via Auth Proxy (no VPN needed):
+  ┌───────────────┐   Cloud SQL Auth Proxy   ┌──────────────────────┐
+  │  Cloud Run    │ ────────────────────────►│  agentic-rag-pg      │
+  │  agentic-rag  │   (IAM authentication)   │  PostgreSQL 15       │
+  └───────────────┘                          │  unicon-494419:      │
+                                             │  us-central1:        │
+                                             │  agentic-rag-pg      │
+                                             └──────────────────────┘
+```
+
+**Traffic paths:**
+
+| Source | Destination | Path |
+|--------|-------------|------|
+| Cloud Run | YISBeta SQL Server (10.0.0.22:1433) | VPC Connector → VPN Tunnel → Youngsinc LAN |
+| Cloud Run | Cloud SQL PostgreSQL | Cloud SQL Auth Proxy (IAM, no VPN) |
+| Local dev | YISBeta SQL Server | Docker IKEv2 tunnel → localhost:14333 |
+
+---
+
+## Prerequisites
+
+- GCP project: `unicon-494419`
+- `gcloud` CLI authenticated: `gcloud auth login`
+- Youngsinc VPN peer details:
+  - Peer IP: `72.240.11.135` (remote.youngsinc.com)
+  - Pre-Shared Key (PSK): stored locally only — never committed to git
+  - Client LAN subnet: `10.0.0.0/16`
+  - Protocol: IKEv2, AES-256-GCM, SHA-512, DH Group 20
+
+---
+
+## Step 1 — Reserve a Static External IP
+
+```bash
+gcloud compute addresses create youngsinc-vpn-ip \
+  --project=unicon-494419 \
+  --region=us-central1
+
+# Verify
+gcloud compute addresses describe youngsinc-vpn-ip \
+  --region=us-central1 \
+  --format="value(address)"
+# → 34.10.184.224
+```
+
+**Why**: The Cloud-side VPN peer IP must be static so Youngsinc can pin it in their firewall/VPN config.
+
+---
+
+## Step 2 — Create the Classic VPN Gateway
+
+```bash
+gcloud compute vpn-gateways create youngsinc-vpn-gateway \
+  --project=unicon-494419 \
+  --region=us-central1 \
+  --network=default
+```
+
+**Why Classic VPN (not HA VPN)**: Youngsinc's end is a single-peer policy-based VPN. Classic VPN supports route-based and policy-based peers. HA VPN requires two tunnels and BGP on both sides.
+
+Create the three forwarding rules needed for IPSec Classic VPN:
+
+```bash
+# ESP (IP protocol 50) — encrypted IPSec payload
+gcloud compute forwarding-rules create youngsinc-fr-esp \
+  --project=unicon-494419 --region=us-central1 \
+  --ip-protocol=ESP --address=youngsinc-vpn-ip \
+  --target-vpn-gateway=youngsinc-vpn-gateway
+
+# IKE UDP 500 — key exchange
+gcloud compute forwarding-rules create youngsinc-fr-udp500 \
+  --project=unicon-494419 --region=us-central1 \
+  --ip-protocol=UDP --ports=500 --address=youngsinc-vpn-ip \
+  --target-vpn-gateway=youngsinc-vpn-gateway
+
+# NAT-T UDP 4500 — IKEv2 NAT traversal
+gcloud compute forwarding-rules create youngsinc-fr-udp4500 \
+  --project=unicon-494419 --region=us-central1 \
+  --ip-protocol=UDP --ports=4500 --address=youngsinc-vpn-ip \
+  --target-vpn-gateway=youngsinc-vpn-gateway
+```
+
+---
+
+## Step 3 — Create the VPN Tunnel (IKEv2)
+
+```bash
+gcloud compute vpn-tunnels create youngsinc-tunnel \
+  --project=unicon-494419 \
+  --region=us-central1 \
+  --vpn-gateway=youngsinc-vpn-gateway \
+  --peer-address=72.240.11.135 \
+  --shared-secret='<PSK — stored in run_vpn_tunnel.sh, not in git>' \
+  --ike-version=2 \
+  --local-traffic-selector=0.0.0.0/0 \
+  --remote-traffic-selector=0.0.0.0/0
+
+# Verify status
+gcloud compute vpn-tunnels describe youngsinc-tunnel \
+  --region=us-central1 \
+  --format="value(status,detailedStatus)"
+# → ESTABLISHED
+```
+
+**IKE parameters negotiated with Youngsinc:**
+
+| Parameter | Value |
+|-----------|-------|
+| IKE version | IKEv2 |
+| Encryption | AES-256-GCM |
+| Integrity | SHA-512 |
+| DH Group | Group 20 (ECP-384) |
+| Authentication | Pre-Shared Key (PSK) |
+
+---
+
+## Step 4 — Add a Route for the Client Subnet
+
+```bash
+gcloud compute routes create youngsinc-route-10x \
+  --project=unicon-494419 \
+  --network=default \
+  --destination-range=10.0.0.0/16 \
+  --next-hop-vpn-tunnel=youngsinc-tunnel \
+  --next-hop-vpn-tunnel-region=us-central1 \
+  --priority=1000
+```
+
+This tells GCP's VPC: _any traffic destined for 10.0.0.0/16 (Youngsinc LAN) should go through the VPN tunnel_.
+
+---
+
+## Step 5 — Create Firewall Rules
+
+```bash
+# Allow inbound traffic from Youngsinc LAN to GCP resources
+gcloud compute firewall-rules create allow-youngsinc-vpn-ingress \
+  --project=unicon-494419 \
+  --network=default \
+  --direction=INGRESS \
+  --source-ranges=10.0.0.0/16 \
+  --allow=tcp,udp,icmp \
+  --priority=1000 \
+  --description="Allow traffic from Youngsinc LAN via VPN"
+```
+
+> **Note**: Outbound (egress) traffic from GCP VMs/Cloud Run to 10.0.0.0/16 is allowed by default in GCP VPCs. Only ingress rules are needed.
+
+---
+
+## Step 6 — Create a Serverless VPC Access Connector
+
+Cloud Run is serverless and does **not** live inside the VPC by default. A VPC Access Connector bridges Cloud Run into the VPC so it can use the VPN tunnel.
+
+```bash
+gcloud services enable vpcaccess.googleapis.com --project=unicon-494419
+
+gcloud compute networks vpc-access connectors create youngsinc-connector \
+  --project=unicon-494419 \
+  --region=us-central1 \
+  --network=default \
+  --range=172.16.0.0/28 \
+  --min-instances=2 \
+  --max-instances=3 \
+  --machine-type=f1-micro
+
+# Verify
+gcloud compute networks vpc-access connectors describe youngsinc-connector \
+  --region=us-central1 \
+  --format="value(state)"
+# → READY
+```
+
+**CIDR choice for connector**: `172.16.0.0/28` was chosen because:
+- `10.0.0.0/8` is taken by Youngsinc LAN
+- `10.8.0.0/28` conflicted with an existing GCP subnet
+- `172.16.0.0/28` was free in RFC 1918 space
+
+The `/28` provides 16 IPs, sufficient for the 2–3 connector instances.
+
+---
+
+## Step 7 — Configure Cloud Run to Use the Connector
+
+When deploying (or updating) the Cloud Run service, specify the connector and egress mode:
+
+```bash
+gcloud run deploy agentic-rag \
+  --project=unicon-494419 \
+  --region=us-central1 \
+  --source . \
+  --vpc-connector=youngsinc-connector \
+  --vpc-egress=private-ranges-only \
+  --allow-unauthenticated
+```
+
+`--vpc-egress=private-ranges-only` means only RFC 1918 traffic (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) goes through the VPC connector/VPN. Public internet traffic (e.g. Gemini API) goes directly — no performance penalty.
+
+**To switch the default database without redeploying:**
+
+```bash
+# Switch to Cloud SQL PostgreSQL
+gcloud run services update agentic-rag \
+  --region=us-central1 \
+  --update-env-vars="DB_DEFAULT_ALIAS=local_pg"
+
+# Switch back to YISBeta SQL Server
+gcloud run services update agentic-rag \
+  --region=us-central1 \
+  --update-env-vars="DB_DEFAULT_ALIAS=yisbeta"
+```
+
+---
+
+## Step 8 — Cloud SQL (PostgreSQL)
+
+Cloud SQL is accessed via the **Cloud SQL Auth Proxy** — an IAM-authenticated, TLS-encrypted sidecar that Cloud Run manages automatically (no VPN required for Cloud SQL).
+
+```bash
+# Create the instance
+gcloud sql instances create agentic-rag-pg \
+  --project=unicon-494419 \
+  --region=us-central1 \
+  --database-version=POSTGRES_15 \
+  --tier=db-f1-micro
+
+# Create the database
+gcloud sql databases create agentic_rag \
+  --instance=agentic-rag-pg
+
+# Create the app user
+gcloud sql users create app_user \
+  --instance=agentic-rag-pg \
+  --password='<generated-password>'
+
+# Store the password in Secret Manager
+gcloud secrets create local-pg-password --replication-policy=automatic
+echo -n '<generated-password>' | gcloud secrets versions add local-pg-password --data-file=-
+```
+
+In `connections.json`, the Cloud SQL entry uses `instance_connection_name` so the Auth Proxy knows which instance to connect to:
+
+```json
+{
+  "alias": "local_pg",
+  "db_type": "postgres",
+  "host": "127.0.0.1",
+  "port": 5432,
+  "database": "agentic_rag",
+  "user": "app_user",
+  "password_secret": "projects/unicon-494419/secrets/local-pg-password/versions/latest",
+  "instance_connection_name": "unicon-494419:us-central1:agentic-rag-pg"
+}
+```
+
+---
+
+## Step 9 — Secret Manager for Credentials
+
+All database passwords are stored in GCP Secret Manager — **never in environment variables or config files in git**.
+
+```bash
+# Grant the Cloud Run service account access to secrets
+SA="664984131730-compute@developer.gserviceaccount.com"
+
+gcloud secrets add-iam-policy-binding yisbeta-db-password \
+  --member="serviceAccount:${SA}" --role="roles/secretmanager.secretAccessor"
+
+gcloud secrets add-iam-policy-binding local-pg-password \
+  --member="serviceAccount:${SA}" --role="roles/secretmanager.secretAccessor"
+```
+
+At runtime, `connections.py` calls `google.cloud.secretmanager` to fetch the latest version. The service account's identity is automatically provided by Cloud Run's metadata server — no keys or service account JSON files needed.
+
+---
+
+## Local Dev — Docker IKEv2 Tunnel
+
+For local development, the VPN tunnel is replicated inside a Docker container using **strongSwan** (IKEv2).
+
+```
+┌──────────────────────────────────────┐
+│  MacBook (localhost)                 │
+│                                      │
+│  agentic-rag agent  → localhost:14333│
+│                       ↓              │
+│  ┌─────────────────────────────────┐ │
+│  │  Docker: youngsinc-tunnel       │ │
+│  │  strongSwan IKEv2 + socat       │ │
+│  │  PORT 14333 mapped to ppp0:1433 │ │
+│  └────────────┬────────────────────┘ │
+└───────────────┼──────────────────────┘
+                │ IKEv2 (UDP 500/4500, ESP)
+        72.240.11.135 → 10.0.0.22:1433
+```
+
+**Setup:**
+
+```bash
+# 1. Copy the template (fill in credentials — NEVER commit run_vpn_tunnel.sh)
+cp scripts/docker_vpn/run_vpn_tunnel.sh.example scripts/docker_vpn/run_vpn_tunnel.sh
+# Edit: VPN_SERVER, VPN_PSK, TARGET_HOST, TARGET_PORT
+
+# 2. Start the tunnel
+cd scripts/docker_vpn && bash run_vpn_tunnel.sh
+
+# 3. Verify
+nc -zv localhost 14333 && echo "CONNECTED"
+
+# 4. In connections.json, use alias: yisbeta_tunnel
+```
+
+The `yisbeta_tunnel` connection is marked `"local_only": true` so it is hidden in the Cloud Run UI automatically — it only appears when the app is accessed via localhost.
+
+**Stop the tunnel:**
+```bash
+bash scripts/docker_vpn/stop_vpn_tunnel.sh
+```
+
+---
+
+## Security Assessment
+
+### ✅ What is Secured
+
+| Control | Detail |
+|---------|--------|
+| **VPN encryption** | IKEv2, AES-256-GCM (AEAD), SHA-512, DH Group 20 (ECP-384 = 192-bit equivalent) — NIST-recommended post-2025 algorithms |
+| **Pre-Shared Key** | PSK never stored in git; gitignored in `run_vpn_tunnel.sh`; CI/CD has no access to it |
+| **DB passwords** | All passwords in GCP Secret Manager with version pinning (`/versions/latest`) |
+| **Secret access IAM** | Only the Cloud Run service account (`664984131730-compute@developer.gserviceaccount.com`) holds `roles/secretmanager.secretAccessor` — no human accounts |
+| **Cloud SQL auth** | Auth Proxy uses IAM identity — no network-level SQL password transmitted on the wire |
+| **Cloud Run egress** | `vpc-egress=private-ranges-only` — private traffic via VPN, public traffic (Gemini) direct. No traffic mixing |
+| **Branch protection** | `main` requires 1 PR review + enforce_admins — no direct pushes |
+| **No hardcoded secrets** | `connections.json` references secret paths, not values. `.env` is gitignored |
+
+### ⚠️ Residual Risks and Mitigations
+
+| Risk | Severity | Current State | Recommended Mitigation |
+|------|----------|---------------|------------------------|
+| **PSK is static** | Medium | PSK shared with Youngsinc admin out-of-band | Rotate PSK quarterly; consider migrating to certificate-based IKEv2 |
+| **SQL Server user `3vAnalysts2` scope** | Medium | Unknown if least-privilege | Confirm with Youngsinc that the account is read-only or limited to required tables |
+| **Cloud Run is `--allow-unauthenticated`** | Medium | Open to public internet (required for UI) | Add Cloud Armor WAF, or Identity-Aware Proxy (IAP) for authenticated access |
+| **Classic VPN (single tunnel)** | Low | Single point of failure if tunnel drops | Migrate to HA VPN with two tunnels for production SLA |
+| **VPC connector CIDR is RFC 1918** | Low | `172.16.0.0/28` not overlapping anything currently | Document if network is expanded |
+| **Secret versions set to `latest`** | Low | Auto-picks latest version | Pin to specific version IDs in production to prevent accidental rotation breakage |
+| **Local dev PSK on developer Macs** | Low | In gitignored `run_vpn_tunnel.sh` only | Use 1Password/Vault for developer secret distribution instead of sharing PSK directly |
+
+### Network Flow Security Summary
+
+```
+User Browser
+    │  HTTPS (TLS 1.3)
+    ▼
+Cloud Run (HTTPS endpoint, Google-managed cert)
+    │  IAM + Secret Manager API (TLS, IAM-authenticated)
+    ▼
+Secret Manager (fetches DB password)
+    │
+    ├── For YISBeta ──► VPC Connector ──► Classic VPN (IKEv2, AES-256-GCM) ──► SQL Server 1433
+    │                   (RFC 1918 only)    (encrypted tunnel)                  (TDS/SQL payload)
+    │
+    └── For Cloud SQL ──► Cloud SQL Auth Proxy (IAM + TLS) ──► PostgreSQL
+                          (mTLS, Google-internal)
+```
+
+---
+
+## Troubleshooting Reference
+
+### VPN Tunnel Down
+
+```bash
+# Check tunnel status
+gcloud compute vpn-tunnels describe youngsinc-tunnel \
+  --region=us-central1 \
+  --format="value(status,detailedStatus)"
+
+# Common statuses:
+# ESTABLISHED — working
+# WAITING_FOR_FULL_CONFIG — IKE SA up but no traffic selectors agreed yet
+# FIRST_HANDSHAKE — negotiating; wait 60s and re-check
+# NO_INCOMING_PACKETS — firewall at Youngsinc may be blocking UDP 500/4500
+```
+
+### Cloud Run Cannot Reach 10.0.0.22
+
+```bash
+# Verify connector is READY
+gcloud compute networks vpc-access connectors describe youngsinc-connector \
+  --region=us-central1 --format="value(state)"
+
+# Verify Cloud Run is using the connector
+gcloud run services describe agentic-rag \
+  --region=us-central1 \
+  --format="value(spec.template.metadata.annotations)"
+# Should show run.googleapis.com/vpc-access-connector: youngsinc-connector
+```
+
+### Secret Access Denied
+
+```bash
+# Test secret access manually
+gcloud secrets versions access latest \
+  --secret=yisbeta-db-password \
+  --project=unicon-494419 \
+  --impersonate-service-account=664984131730-compute@developer.gserviceaccount.com
+```
+
+### Cloud SQL Connection Refused
+
+```bash
+# Check instance is running
+gcloud sql instances describe agentic-rag-pg \
+  --format="value(state,backendType)"
+
+# Check app_user exists
+gcloud sql users list --instance=agentic-rag-pg
+```
+
+---
+
+*Document created: March 2026 — unicon-494419 / Agentic RAG project. Maintained in `docs/cloud-connectivity-setup.md`.*

--- a/docs/design-reference.md
+++ b/docs/design-reference.md
@@ -1,0 +1,124 @@
+The Dev-Grade Architecture (Using ADK)
+text
+flowchart TD
+    U["End User (App / API)"] -->|"HTTPS Request"| AE["Vertex AI Agent Engine\n(Managed Runtime)"]
+
+    subgraph ADK ["ADK Multi-Agent System"]
+        RT["Router Agent\n(ADK Supervisor)"]
+        
+        RT -->|"Structured Query"| DBA["Database Agent\n(ADK + Gemini)"]
+        RT -->|"Unstructured Query"| RAGA["RAG Agent\n(ADK + Gemini)"]
+    end
+
+    AE --> RT
+
+    %% Database Agent Flow using MCP
+    subgraph Tooling ["MCP Toolbox (Cloud Run)"]
+        MCP["MCP Server for Databases\n(tools.yaml)"]
+    end
+
+    DBA -->|"Calls tool via MCP Protocol"| MCP
+    MCP -->|"Secure Network (VPN)"| DB[("Client SQL Server\nRead-only")]
+    DB -->|"Result Set"| MCP
+    MCP --> MASK["Presidio PII Masking\n(Middleware)"]
+    MASK -->|"Masked JSON"| DBA
+
+    %% RAG Agent Flow using Vertex AI RAG Engine
+    subgraph RAG_Engine ["Vertex AI RAG Engine"]
+        CORPUS["RAG Corpus\n(Managed Index)"]
+    end
+
+    RAGA -->|"Semantic Search Tool"| CORPUS
+    
+    %% Ingestion Pipeline
+    GCS["Cloud Storage\nRaw Docs"] -->|"Chunk & Embed"| CORPUS
+
+    %% Config
+    DBA -.-> SM["Secret Manager\n(DB Credentials)"]
+    RT -.-> FS["Firestore\n(Tenant Config)"]
+How to build this step-by-step in Dev:
+Install ADK:
+Install the official Google ADK package in your Python environment:
+
+bash
+pip install google-adk mcp
+Set up the MCP Toolbox (for Text-to-SQL):
+
+Deploy the open-source MCP Toolbox for Databases to Cloud Run.
+
+Define a tools.yaml file mapping out the safe, read-only SQL Server queries you allow the LLM to run.
+
+Point the MCP Toolbox at your SQL Server instance via a VPC connector.
+
+Build the ADK Agents:
+
+DB Agent: Give it the ToolboxToolset connected to your MCP server. It will automatically understand the SQL Server schema tools you defined in YAML.
+
+RAG Agent: Give it a RagCorpusTool that connects to Vertex AI RAG Engine (which handles the chunking, embedding, and vector storage for you, completely replacing the need to manage a raw pgvector database yourself).
+
+Router Agent: Use ADK's orchestration to make this the entry point. It evaluates the user's prompt and hands off the session to the DB Agent or the RAG Agent.
+
+Deploy:
+
+Deploy your ADK python code directly to Vertex AI Agent Engine. It will wrap your agents in a scalable API, provide out-of-the-box evaluation metrics, and handle the multi-tenant session state.
+
+Using ADK + MCP Toolbox is the most modern, Google-recommended way to build this exact "Rack system" today. It separates the AI logic (ADK) from the database infrastructure logic (MCP Toolbox), making it incredibly easy to plug in new clients later.
+
+
+
+
+
+
+
+
+GitHub Repos to Reference
+Here are the exact repos — ordered by how directly they match your use case:
+
+1. Official MCP Toolbox for Databases
+🔗 
+https://github.com/googleapis/genai-toolbox
+
+The core open-source MCP server you will deploy to Cloud Run. Has SQL Server support, tools.yaml examples, connection pooling, and auth.
+
+2. Official Codelab Repo (ADK + MCP Toolbox + Cloud SQL + pgvector)
+🔗 
+https://github.com/paulramsey/adk-toolbox-agent
+
+This is the hands-on reference for exactly what you are building. It shows how to write tools.yaml, load toolsets in ADK, deploy to Cloud Run, and run vector search via pgvector.
+
+3. ADK + Vertex AI RAG Engine
+🔗 
+https://github.com/arjunprabhulal/adk-vertex-ai-rag-engine
+
+Shows how to hook up the document RAG path using RagCorpusTool inside an ADK agent connected to Vertex AI RAG Engine — covers the unstructured docs side of your design.
+​
+
+4. ADK RAG Agent (Vertex AI)
+🔗 
+https://github.com/bhancockio/adk-rag-agent
+
+A clean, minimal ADK RAG agent using Vertex AI — good starting point for understanding the agent code structure before adding multi-tenancy.
+​
+
+5. ADK + MCP + Qdrant RAG
+🔗 
+https://github.com/khoi03/adk-mcp-rag
+
+Shows how to combine ADK + MCP + a vector database for RAG. While it uses Qdrant instead of Cloud SQL, the agent code pattern is identical — swap the vector store for yours.
+​
+
+6. Official ADK Sample Agents
+🔗 
+https://github.com/google/adk-samples
+
+Google's official collection of production-ready ADK agent samples across many use cases — good for understanding multi-agent orchestration patterns.
+​
+
+Recommended Build Order for Your Dev Environment
+Start with Repo #2 (adk-toolbox-agent) — get the MCP Toolbox running against Cloud SQL PostgreSQL locally first, even before touching SQL Server. This proves the end-to-end Text-to-SQL flow works in your GCP project.
+
+Swap the source in tools.yaml from cloud-sql-postgres to mssql (SQL Server) once the Postgres version is confirmed working.
+
+Add the RAG Agent from Repo #3 as a second agent under your Router Agent.
+
+Add the Firestore tenant config and Secret Manager lookups last — this upgrades it from single-client dev to a proper multi-tenant rack.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,0 +1,90 @@
+# Implementation & Testing Plan
+
+## Scope
+
+- Phase 1: Implement PostgreSQL-first Agentic RAG with Python 3.12+.
+- Phase 2: Add SQL Server support with behavior parity and no core router rewrite.
+
+## Phase 1 — PostgreSQL implementation
+
+### Deliverables
+
+1. Router/DB/RAG agent runtime in Python.
+2. MCP toolbox setup with PostgreSQL read-only tools (`tools.postgres.yaml`).
+3. Tenant-aware request envelope (tenant id passed through route handlers).
+4. PII masking middleware contract (to be plugged in after DB response).
+5. Vertex AI RAG corpus integration contract.
+
+### Work breakdown
+
+1. Bootstrap app skeleton and route logic.
+2. Connect `DatabaseAgent` to MCP endpoint and implement tool call adapters.
+3. Connect `RagAgent` to Vertex AI RAG corpus retrieval.
+4. Add policy/guardrails:
+   - read-only tools only,
+   - query size and row limits,
+   - allowlisted schemas/tables,
+   - prompt injection checks before tool execution.
+5. Add observability and request tracing (route, tool, latency, tenant).
+
+## Phase 1 — testing strategy (PostgreSQL)
+
+### Unit tests
+
+- Query classification and route selection.
+- Guardrail logic (disallowed keywords, over-limit requests).
+- Response normalization and masking integration points.
+
+### Integration tests
+
+- Router -> DB agent -> MCP toolbox -> PostgreSQL (seed database).
+- Router -> RAG agent -> Vertex RAG retrieval path.
+- Secret/config loading for local dev and CI.
+
+### Security tests
+
+- Prompt injection attempts against DB tools.
+- Unauthorized schema/table access attempts.
+- PII leakage tests pre/post masking stage.
+
+### Non-functional tests
+
+- p50/p95 latency by route.
+- Concurrency smoke tests.
+- Timeout and retry behavior.
+
+### Exit criteria
+
+- 100% pass for critical route + guardrail tests.
+- No write query execution path.
+- Stable integration test run in CI.
+
+## Phase 2 — SQL Server plan
+
+### Migration approach
+
+Keep application layer stable (`RouterAgent`, contracts, test harness) and swap:
+
+1. MCP datasource configuration from PostgreSQL to SQL Server.
+2. Tool SQL from PostgreSQL dialect to SQL Server dialect.
+3. SQL Server authentication/network configuration.
+
+### SQL Server-specific implementation tasks
+
+1. Create `config/tools.sqlserver.yaml` with read-only allowlisted queries.
+2. Add dialect adapter for pagination/date/null differences where needed.
+3. Add SQL Server connection settings and secret references.
+4. Validate collation/case-sensitivity assumptions.
+
+### SQL Server testing (parity suite)
+
+1. Run full Phase 1 suite against SQL Server.
+2. Add cross-DB parity tests for canonical prompts.
+3. Compare semantic equivalence of responses and acceptable tolerance ranges.
+4. Benchmark latency deltas and update SLO thresholds.
+
+### SQL Server exit criteria
+
+- Phase 1 critical tests pass unchanged.
+- Cross-DB parity thresholds met.
+- No new high-severity security findings.

--- a/docs/min-prod-rollout.md
+++ b/docs/min-prod-rollout.md
@@ -1,0 +1,61 @@
+# Minimum Production Rollout (Tagged to Agentic_RAG)
+
+All resources must include labels:
+
+- `app=agentic-rag`
+- `system=agentic-rag`
+- `env=minprod`
+
+## 1) Create Cloud SQL PostgreSQL
+
+```bash
+gcloud sql instances create agentic-rag-pg \
+  --database-version=POSTGRES_15 \
+  --cpu=2 \
+  --memory=8GiB \
+  --region=us-central1 \
+  --storage-size=20GB \
+  --storage-type=SSD \
+  --availability-type=zonal \
+  --labels=app=agentic-rag,system=agentic-rag,env=minprod
+
+gcloud sql databases create agentic_rag --instance=agentic-rag-pg
+gcloud sql users create app_user --instance=agentic-rag-pg --password='<STRONG_PASSWORD>'
+```
+
+## 2) Seed Schema + Sample Data
+
+```bash
+python scripts/seed_cloudsql.py \
+  --instance-connection-name=<PROJECT_ID>:us-central1:agentic-rag-pg \
+  --db-user=app_user \
+  --db-password='<STRONG_PASSWORD>' \
+  --db-name=agentic_rag \
+  --sql-file=sql/min_prod_seed.sql
+```
+
+## 3) Deploy ADK Chat UI on Cloud Run
+
+```bash
+adk deploy cloud_run \
+  --project=<PROJECT_ID> \
+  --region=us-central1 \
+  --service_name=agentic-rag-chat \
+  --with_ui \
+  --otel_to_cloud \
+  --trace_to_cloud \
+  --session_service_uri=memory:// \
+  src/agentic_rag \
+  -- \
+  --labels=app=agentic-rag,system=agentic-rag,env=minprod \
+  --add-cloudsql-instances=<PROJECT_ID>:us-central1:agentic-rag-pg \
+  --set-env-vars=DB_INSTANCE_CONNECTION_NAME=<PROJECT_ID>:us-central1:agentic-rag-pg,DB_NAME=agentic_rag,DB_USER=app_user,DB_PASSWORD=<STRONG_PASSWORD>
+```
+
+## 4) Verify
+
+- Open Cloud Run service URL and use ADK web chat.
+- Ask:
+  - `Show recent orders`
+  - `Summarize sales by region`
+  - `Who are our top customers by lifetime value?`

--- a/docs/prod-readiness.md
+++ b/docs/prod-readiness.md
@@ -1,0 +1,95 @@
+# Production Readiness Blueprint
+
+This document maps production requirements to the current implementation.
+
+## Architecture
+
+```
+Router Agent (agentic_rag_router) — ADK LlmAgent supervisor
+  ├─ database_agent  — Text-to-SQL via pg8000 + guardrails
+  └─ rag_agent       — Vertex AI RAG Engine retrieval
+```
+
+All agent definitions live in a single file: `src/agentic_rag/agent.py`.
+
+## 1) Multi-Agent Routing
+
+- Implemented: ADK `LlmAgent` with `sub_agents=[database_agent, rag_agent]`.
+- The LLM supervisor decides which sub-agent to delegate to based on the question.
+- No heuristic routing code on the hot path — the model handles intent classification.
+- File: `src/agentic_rag/agent.py`
+
+## 2) Text-to-SQL (Database Agent)
+
+- LLM generates SQL dynamically from schema metadata (not pre-canned queries).
+- Guardrails: read-only enforcement, blocked DML keywords, allowed-table list,
+  auto LIMIT injection, statement_timeout.
+- Database connection: pg8000 with multi-fallback (TCP → Unix socket → socket+suffix).
+- File: `src/agentic_rag/agent.py` — tools `get_schema_metadata`, `run_readonly_sql`
+
+## 3) Vertex AI RAG Engine
+
+- Implemented: `retrieve_documents` tool calls `vertexai.preview.rag.retrieval_query`.
+- Controlled by `VERTEX_RAG_CORPUS` env var; gracefully returns "not configured" when empty.
+- Recommended next steps:
+  - Cloud Run Job for batch ingestion (GCS → chunk/embed/import into RAG corpus)
+  - Event trigger from GCS to invoke ingestion job
+- File: `src/agentic_rag/agent.py` — tool `retrieve_documents`
+
+## 4) PII Masking
+
+- Implemented: `PIIMasker` with regex fallback (email, SSN, name) + optional Presidio.
+- Wired into `run_readonly_sql` — all query results are masked before reaching the LLM.
+- Controlled by `PII_MASKING_ENABLED`, `PII_USE_PRESIDIO`, `PII_DEFAULT_RULES`.
+- Files: `src/agentic_rag/agent.py`, `src/agentic_rag/pii_masking.py`
+
+## 5) DB Credential Security
+
+- Supports plain `DB_PASSWORD` env var (dev) or Secret Manager via `DB_PASSWORD_SECRET`.
+- When `DB_PASSWORD_SECRET` is set (e.g., `projects/P/secrets/S/versions/latest`),
+  the password is loaded from Secret Manager at startup.
+- File: `src/agentic_rag/agent.py` — `_resolve_db_password()`
+
+## 6) Multi-Tenant Config (future)
+
+- Scaffolded: tenant resolver with Firestore + Secret Manager integration.
+- Not wired into agent.py yet — for future per-tenant DB/corpus/PII config.
+- File: `src/agentic_rag/tenant_config.py`
+
+## 7) Auth + Security
+
+- Required infra controls (not code-only):
+  - IAP or Identity Platform in front of Cloud Run
+  - JWT claim extraction for tenant mapping
+  - VPC Service Controls perimeter
+  - Cloud Armor WAF + DDoS protections
+
+## 8) Observability + Evaluation
+
+- Recommended:
+  - `--otel_to_cloud` and `--trace_to_cloud` flags in ADK deploy
+  - RAG eval pipeline in Vertex AI for faithfulness/relevancy/precision
+  - Token usage streaming to BigQuery per `tenant_id`
+  - Cloud Monitoring SLO alerts for latency/error/quota
+
+## Deployment
+
+```bash
+adk deploy cloud_run \
+  --project=$GOOGLE_CLOUD_PROJECT \
+  --region=us-central1 \
+  --service_name=agentic-rag-chat \
+  --with_ui \
+  --otel_to_cloud \
+  --trace_to_cloud \
+  --session_service_uri=memory:// \
+  src/agentic_rag
+```
+
+The deployed service exposes ADK API endpoints including `/run` and `/run_sse`.
+
+## Reference Config Templates
+
+The `config/tools.*.yaml` files are reference templates for a potential MCP Toolbox
+migration (pre-defined SQL queries). They are **not used** by the current Text-to-SQL
+approach. See `config/README.md` for details.


### PR DESCRIPTION
Adds docs/cloud-connectivity-setup.md documenting all steps to set up GCP Classic VPN, VPC Access connector, Cloud SQL Auth Proxy, and secure SQL Server access. Includes security assessment and troubleshooting guide. Also unblocks docs/ directory from .gitignore and tracks all existing architecture/design docs.