### PR TITLE
chore: upgrade AGENT_MODEL to gemini-3.0-flash-preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ GOOGLE_CLOUD_PROJECT=your-project-id
 GOOGLE_CLOUD_LOCATION=us-central1
 
 # ── Agent model ──────────────────────────────────────────
-AGENT_MODEL=gemini-2.5-flash
+AGENT_MODEL=gemini-3.0-flash-preview
 
 # ── Database ───────────────────────────────────────────────
 # DB_TYPE: "postgres" (default) or "mssql" for SQL Server

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Key settings:
 | Variable | What it controls |
 |----------|-----------------|
 | `DB_TYPE` | Database backend: `postgres` (default) or `mssql` for SQL Server |
-| `AGENT_MODEL` | Which Gemini model to use (default: `gemini-2.5-flash`) |
+| `AGENT_MODEL` | Which Gemini model to use (default: `gemini-3.0-flash-preview`) |
 | `DB_INSTANCE_CONNECTION_NAME` | Cloud SQL instance path (PostgreSQL only) |
 | `DB_HOST` | Database hostname (required for SQL Server, optional for Cloud SQL) |
 | `DB_PORT` | Database port (auto-defaults: 5432 for PG, 1433 for MSSQL) |

--- a/src/agentic_rag/agent.py
+++ b/src/agentic_rag/agent.py
@@ -640,7 +640,7 @@ def prewarm_schema_cache() -> None:
 
 # ── Agent definitions ────────────────────────────────────────────────────────
 
-_model = os.environ.get("AGENT_MODEL", "gemini-2.5-flash")
+_model = os.environ.get("AGENT_MODEL", "gemini-3.0-flash-preview")
 # Lightweight model for the router — it only picks between 2 sub-agents
 _router_model = os.environ.get("ROUTER_MODEL", "gemini-2.5-flash-lite")
 

--- a/src/agentic_rag/config.py
+++ b/src/agentic_rag/config.py
@@ -18,7 +18,7 @@ class AppSettings(BaseSettings):
     location: str = Field(default="us-central1", alias="GOOGLE_CLOUD_LOCATION")
 
     # ── Agent model ──────────────────────────────────────────
-    agent_model: str = Field(default="gemini-2.5-flash", alias="AGENT_MODEL")
+    agent_model: str = Field(default="gemini-3.0-flash-preview", alias="AGENT_MODEL")
 
     # ── Database ───────────────────────────────────────────────
     # DB_TYPE: "postgres" (default) or "mssql" for SQL Server


### PR DESCRIPTION
Upgrades the sub-agent and database agent model from gemini-2.5-flash to gemini-3.0-flash-preview. Router model stays as gemini-2.5-flash-lite (intent routing only).