### PR TITLE
fix(ui): remove redundant startup system message

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -587,10 +587,6 @@ el.apiBase.addEventListener('change', () => {
   fetchDatabases();
 });
 
-appendMessage('agent', 'System', (target) => {
-  renderText(target, 'Set API base URL, create a session, and start querying. Tool outputs are rendered from JSON.');
-});
-
 /* ── Theme Toggle ──────────────────────────────────────── */
 (function initTheme() {
   const btn = document.getElementById('themeToggle');


### PR DESCRIPTION
Removes the 'Set API base URL, create a session...' message that auto-posts on load — it's unnecessary noise since the UI is self-explanatory.