### PR TITLE
fix: SQL accuracy - correct DB connect, thinking budget, CTE TOP injection, sample row PII

### DIFF
--- a/src/agentic_rag/agent.py
+++ b/src/agentic_rag/agent.py
@@ -331,14 +331,15 @@ def _inject_limit_if_missing(sql: str, max_rows: int, db_type: str = "") -> str:
                 count=1,
             )
         # Plain SELECT or CTE (WITH ... SELECT ...).
-        # Use re.DOTALL so .* spans newlines, matching the outermost SELECT.
-        return re.sub(
-            r"(?i)\bSELECT\b(?!.*\bSELECT\b)",
-            f"SELECT TOP {max_rows}",
-            sql,
-            count=1,
-            flags=re.DOTALL,
-        )
+        # Find the LAST SELECT (the outermost projection in a CTE) and inject TOP N.
+        # Using rfind on lowercased sql is simpler and more reliable than a
+        # negative-lookahead regex which fails on multi-line CTEs.
+        lowered = sql.lower()
+        last_select_pos = lowered.rfind('select')
+        if last_select_pos == -1:
+            return sql  # no SELECT found — return as-is
+        after_select = sql[last_select_pos + len('select'):]
+        return sql[:last_select_pos] + f"SELECT TOP {max_rows}" + after_select
 
     # PostgreSQL uses LIMIT
     if " limit " in f" {normalized} ":
@@ -411,7 +412,7 @@ def get_schema_metadata(tool_context: ToolContext) -> dict[str, Any]:
             cached["today"] = datetime.date.today().isoformat()
             return cached  # type: ignore[return-value]
 
-    conn = _connect()
+    conn = _connect(cfg)  # MUST pass cfg so the right DB alias is used
     try:
         cur = conn.cursor()
 
@@ -472,7 +473,7 @@ def get_schema_metadata(tool_context: ToolContext) -> dict[str, Any]:
                     )
                 else:
                     cur.execute(f'SELECT * FROM "{tname}" LIMIT 2')
-                samples[tname] = _to_rows(cur)
+                samples[tname] = _mask_rows(_to_rows(cur))  # mask PII in sample rows too
             except Exception:
                 samples[tname] = []
 
@@ -676,7 +677,7 @@ _no_think = BuiltInPlanner(
     thinking_config=types.ThinkingConfig(thinking_budget=0)
 )
 _light_think = BuiltInPlanner(
-    thinking_config=types.ThinkingConfig(thinking_budget=1024)
+    thinking_config=types.ThinkingConfig(thinking_budget=8192)  # higher budget = more accurate SQL
 )
 _fast_config = types.GenerateContentConfig(
     max_output_tokens=2048,


### PR DESCRIPTION
## Critical bug fixes for SQL query accuracy

### Bug 1 — CRITICAL: wrong DB connection in get_schema_metadata
`get_schema_metadata` resolved `db_alias` into `cfg` but then called `_connect()` with no arguments.
This meant the schema was always fetched from the env-var default DB (`yisbeta` = `10.0.0.22`, deleted tunnel)
regardless of which alias the session selected. Fixed: `conn = _connect(cfg)`.

### Bug 2 — DB_DEFAULT_ALIAS pointed to deleted VPN tunnel
Cloud Run had `DB_DEFAULT_ALIAS=yisbeta` (direct IP `10.0.0.22`, VPN tunnel deleted 3/2).
Fixed via `gcloud run services update --update-env-vars DB_DEFAULT_ALIAS=yisbeta_relay_vm` — already live as revision `agentic-rag-00011-47z`.

### Bug 3 — Thinking budget too low for complex SQL
Increased `thinking_budget` from `1024` to `8192` tokens for `database_agent`.
More chain-of-thought = correct JOINs, GROUP BY, date arithmetic for "last year" queries.

### Bug 4 — Sample rows in schema had unmasked PII
`sample_rows` were fetched raw and sent unmasked to LLM context.
Fixed: `_mask_rows()` now applied to sample rows before caching.

### Bug 5 — TOP N injection broke on CTEs with nested SELECTs
The negative-lookahead regex `(?!.*\bSELECT\b)` with `re.DOTALL` matched the wrong SELECT in multi-line CTEs.
Fixed: `rfind('select')` on the normalized SQL reliably finds the last (outermost) SELECT.
