### PR TITLE
docs: populate CLOUD_ENV_SETUP.md and add vpn_relay_vm setup script

### DIFF
--- a/CLOUD_ENV_SETUP.md
+++ b/CLOUD_ENV_SETUP.md
@@ -1,0 +1,280 @@
+# Cloud Environment Setup
+
+Complete reference for the GCP infrastructure, VPN relay, and Cloud Run deployment backing this project.
+
+---
+
+## GCP Project
+
+| Item | Value |
+|---|---|
+| Project ID | `unicon-494419` |
+| Region | `us-central1` |
+| Auth account | `sbheema@swardesi.com` |
+
+---
+
+## Architecture Overview
+
+```
+Browser / UI
+    │
+    ▼
+Cloud Run: agentic-rag-chat
+    │  (Vertex AI Gemini for LLM)
+    │  (VPC Connector → private egress)
+    │
+    ▼
+VPC Connector: ai-factory-connector (10.8.0.0/28)
+    │
+    ▼
+GCE VM: yisbeta-vpn-relay (10.128.0.3)
+    │  Docker container: youngsinc-tunnel
+    │  socat: 0.0.0.0:1433 → 10.0.0.22:1433
+    │
+    ▼
+L2TP/IPSec VPN Tunnel (ppp0 → 10.20.30.210)
+    │
+    ▼
+YISBeta SQL Server (10.0.0.22:1433)
+```
+
+---
+
+## Cloud Run Service
+
+| Item | Value |
+|---|---|
+| Service name | `agentic-rag-chat` |
+| Region | `us-central1` |
+| URL | `https://agentic-rag-chat-6slvib5z6a-uc.a.run.app` |
+| UI | `https://agentic-rag-chat-6slvib5z6a-uc.a.run.app/app/` |
+| API health | `https://agentic-rag-chat-6slvib5z6a-uc.a.run.app/healthz/db` |
+| Container image | `gcr.io/unicon-494419/agentic-rag-adk:latest` |
+| VPC connector | `ai-factory-connector` |
+| VPC egress | `private-ranges-only` |
+
+### Environment Variables
+
+| Variable | Value |
+|---|---|
+| `AGENT_MODEL` | `gemini-2.5-flash-lite` |
+| `GOOGLE_GENAI_USE_VERTEXAI` | `true` |
+| `GOOGLE_CLOUD_PROJECT` | `unicon-494419` |
+| `GOOGLE_CLOUD_LOCATION` | `us-central1` |
+| `DB_DEFAULT_ALIAS` | `yisbeta_relay_vm` |
+
+### Build & Deploy
+
+```bash
+# Build
+gcloud builds submit \
+  --tag gcr.io/unicon-494419/agentic-rag-adk:latest \
+  --project=unicon-494419
+
+# Deploy
+gcloud run deploy agentic-rag-chat \
+  --image gcr.io/unicon-494419/agentic-rag-adk:latest \
+  --project=unicon-494419 \
+  --region=us-central1
+
+# Update env vars (use --update-env-vars to avoid wiping existing vars)
+gcloud run services update agentic-rag-chat \
+  --region=us-central1 \
+  --update-env-vars="KEY=VALUE"
+```
+
+---
+
+## VPC Connector
+
+| Item | Value |
+|---|---|
+| Name | `ai-factory-connector` |
+| Network | `default` |
+| IP range | `10.8.0.0/28` |
+| Region | `us-central1` |
+
+Cloud Run uses this connector for all egress to private IP ranges (SQL Server relay VM, etc.).
+
+---
+
+## VPN Relay VM
+
+| Item | Value |
+|---|---|
+| Name | `yisbeta-vpn-relay` |
+| Zone | `us-central1-f` |
+| Machine type | `e2-micro` |
+| Internal IP | `10.128.0.3` |
+| External IP | None (IAP tunnel only) |
+| Network tags | `vpn-relay`, `yisbeta-vpn-relay` |
+
+### SSH Access (via IAP — no external IP needed)
+
+```bash
+gcloud compute ssh yisbeta-vpn-relay \
+  --project=unicon-494419 \
+  --zone=us-central1-f \
+  --tunnel-through-iap \
+  --quiet
+```
+
+### Firewall Rule
+
+```
+Rule: allow-cloudrun-to-vpn-relay
+Direction: INGRESS
+Target tags: yisbeta-vpn-relay
+Source ranges: 10.8.0.0/28  (VPC connector range)
+Allowed: tcp:1433
+```
+
+### Routing Fix (persistent)
+
+The VPN container adds a `10.0.0.0/8 via ppp0` host route that intercepts reply packets destined for Cloud Run's `10.8.0.2`. A static route is injected at boot to fix this:
+
+```bash
+ip route add 10.8.0.0/28 via 10.128.0.1 dev ens4
+```
+
+Persisted via two mechanisms:
+- `/etc/rc.local` — runs on every boot
+- `/etc/systemd/system/vpn-routing-fix.service` — runs after `docker.service`
+
+---
+
+## Docker VPN Container
+
+| Item | Value |
+|---|---|
+| Container name | `youngsinc-tunnel` |
+| Image | `youngsinc-vpn-tunnel` (built locally on VM) |
+| Restart policy | `unless-stopped` |
+| Network mode | `--network=host` |
+| VPN type | L2TP/IPSec (IKEv1), PSK auth |
+| VPN server | `remote.youngsinc.com` (72.240.11.135) |
+| Tunnel interface | `ppp0` → assigned IP `10.20.30.210` |
+| socat forward | `0.0.0.0:1433` → `10.0.0.22:1433` via ppp0 |
+
+### Check VPN Status
+
+```bash
+# Check ppp0 is up with an IP
+sudo docker exec youngsinc-tunnel ip addr show ppp0 | grep inet
+
+# Check socat is listening
+sudo docker exec youngsinc-tunnel ss -tlnp | grep 1433
+
+# Tail container logs
+sudo docker logs youngsinc-tunnel --tail=50 -f
+
+# Check container restart count (should stay 0)
+sudo docker inspect youngsinc-tunnel --format='{{.RestartCount}}'
+```
+
+### Rebuild VPN Container
+
+```bash
+sudo docker rm -f youngsinc-tunnel
+cd /opt/Agentic_RAG_ADK && sudo git pull
+cd scripts/docker_vpn && sudo docker build -t youngsinc-vpn-tunnel .
+# Then restart via setup script or manually with credentials
+```
+
+---
+
+## SQL Server (YISBeta)
+
+| Item | Value |
+|---|---|
+| Host (VPN-side) | `10.0.0.22` |
+| Port | `1433` |
+| Database | `YISBeta` |
+| User | `3vAnalysts2` |
+| Reachable via | `yisbeta-vpn-relay:1433` → socat → VPN → `10.0.0.22:1433` |
+| Password secret | `projects/unicon-494419/secrets/yisbeta-db-password/versions/latest` |
+
+### Test DB Connectivity from Cloud Run
+
+```bash
+curl -s "https://agentic-rag-chat-6slvib5z6a-uc.a.run.app/healthz/db"
+# Expected: {"db_connectivity": {"yisbeta_relay_vm": "REACHABLE (10.128.0.3:1433)", ...}}
+```
+
+---
+
+## Secret Manager
+
+| Secret name | Used for |
+|---|---|
+| `yisbeta-db-password` | YISBeta SQL Server password (`3vAnalysts2` user) |
+
+```bash
+# Grant Cloud Run service account access
+gcloud secrets add-iam-policy-binding yisbeta-db-password \
+  --project=unicon-494419 \
+  --member="serviceAccount:SERVICE_ACCOUNT@unicon-494419.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+---
+
+## Connections Config
+
+All DB connections are defined in `connections.json` at the repo root. Currently configured:
+
+| Alias | Host | Type | Notes |
+|---|---|---|---|
+| `yisbeta_relay_vm` | `10.128.0.3:1433` | mssql | **Default** — via VPN relay VM |
+| `yisbeta` | `10.0.0.22:1433` | mssql | Direct (unreachable from Cloud Run) |
+| `yisbeta_tunnel` | `127.0.0.1:14333` | mssql | Local dev via Docker tunnel |
+| `local_pg` | `127.0.0.1:5432` | postgres | Cloud SQL PostgreSQL |
+
+---
+
+## Known Issues & Fixes Applied
+
+### 1. VPN Route Hijacking (FIXED)
+**Problem:** Docker `--network=host` container adds `10.0.0.0/8 via ppp0`. Reply packets to Cloud Run's `10.8.0.2` were routed into the VPN tunnel instead of back to GCP VPC — causing TCP timeouts.  
+**Fix:** `ip route add 10.8.0.0/28 via 10.128.0.1 dev ens4` (persisted via rc.local + systemd).
+
+### 2. `SELECT DISTINCT TOP N` Syntax Error (FIXED)
+**Problem:** The `_inject_limit_if_missing` function in `agent.py` was transforming `SELECT DISTINCT col FROM tbl` into `SELECT TOP 200 DISTINCT col FROM tbl` — invalid T-SQL syntax. SQL Server requires `DISTINCT` before `TOP`.  
+**Fix:** Added DISTINCT-aware branch in `_inject_limit_if_missing` that produces `SELECT DISTINCT TOP N`.
+
+### 3. `--set-env-vars` Wipes All Existing Vars (KNOWN GOTCHA)
+Always use `--update-env-vars` when changing Cloud Run env vars. Using `--set-env-vars` replaces the entire environment and will remove vars set in previous deploys.
+
+### 4. Gemini Model `gemini-3.1-flash-lite-preview` (OBSOLETE)
+Use `gemini-2.5-flash-lite` — the preview model returned 404 on Vertex AI.
+
+---
+
+## Useful Commands
+
+```bash
+# Tail Cloud Run logs live
+gcloud run services logs tail agentic-rag-chat --region=us-central1
+
+# Describe current Cloud Run revision
+gcloud run services describe agentic-rag-chat \
+  --region=us-central1 \
+  --format="yaml(spec.template.spec.containers[0].env)"
+
+# List Cloud Run revisions
+gcloud run revisions list \
+  --service=agentic-rag-chat \
+  --region=us-central1
+
+# Check VPC connector
+gcloud compute networks vpc-access connectors describe ai-factory-connector \
+  --region=us-central1 \
+  --project=unicon-494419
+
+# SSH to relay VM and check VPN in one shot
+gcloud compute ssh yisbeta-vpn-relay \
+  --project=unicon-494419 --zone=us-central1-f \
+  --tunnel-through-iap --quiet \
+  --command="sudo docker exec youngsinc-tunnel ip addr show ppp0 | grep inet"
+```

--- a/scripts/vpn_relay_vm/setup_vpn_relay_vm.sh
+++ b/scripts/vpn_relay_vm/setup_vpn_relay_vm.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# ==============================================================================
+# setup_vpn_relay_vm.sh
+#
+# Creates a GCP e2-micro VM that:
+#   1. Runs the Docker VPN client container (IKEv2 or L2TP/IPSec)
+#   2. Connects to Youngsinc's CLIENT-TO-SITE VPN
+#   3. Forwards 0.0.0.0:1433 → 10.0.0.22:1433 inside the tunnel
+#
+# Cloud Run → VM internal IP:1433 → VPN tunnel → 10.0.0.22:1433 (YISBeta)
+#
+# WHY A VM and not Cloud Run for the VPN container?
+#   Cloud Run is serverless — it does not allow --privileged or NET_ADMIN
+#   capabilities required by IPSec (kernel modules, routing table writes).
+#   A plain GCP Compute VM has no such restrictions.
+#
+# USAGE:
+#   cp setup_vpn_relay_vm.sh.example setup_vpn_relay_vm.sh   ← gitignored
+#   # Fill in credentials below, then:
+#   bash setup_vpn_relay_vm.sh
+#
+# ⚠️  This file is GITIGNORED once renamed — never commit real credentials.
+# ==============================================================================
+set -euo pipefail
+
+# ── Project config ─────────────────────────────────────────────────────────────
+PROJECT="unicon-494419"
+REGION="us-central1"
+ZONE="us-central1-a"
+VM_NAME="yisbeta-vpn-relay"
+MACHINE_TYPE="e2-micro"   # ~$7/month, free-tier eligible
+
+# ── VPN credentials (client-to-site) ──────────────────────────────────────────
+# Fill these in with what Youngsinc gave you.
+VPN_SERVER="remote.youngsinc.com"    # VPN server hostname or IP
+VPN_PSK='<YOUR_PSK>'               # Pre-Shared Key
+VPN_USER="<YOUR_VPN_USERNAME>"                   # Username  (L2TP/IPSec client-to-site)
+VPN_PASS="<YOUR_VPN_PASSWORD>"                 # Password  (L2TP/IPSec client-to-site)
+
+# ── SQL Server target ──────────────────────────────────────────────────────────
+TARGET_HOST="10.0.0.22"
+TARGET_PORT="1433"
+
+# ── Detect VPN mode ───────────────────────────────────────────────────────────
+# Set to "ikev2" if Youngsinc gave you only a PSK (site-to-site / IKEv2).
+# Set to "l2tp"  if they gave you username + password (client-to-site / L2TP).
+VPN_MODE="l2tp"   # L2TP/IPSec with PSK — confirmed
+
+# Repo location inside the VM (will be cloned from GitHub)
+REPO_URL="https://github.com/saibheema/Agentic_RAG_ADK.git"
+REPO_DIR="/opt/Agentic_RAG_ADK"
+DOCKER_DIR="${REPO_DIR}/scripts/docker_vpn"
+
+echo "==> [1/6] Creating VPN relay VM: ${VM_NAME} in ${ZONE}..."
+gcloud compute instances create "${VM_NAME}" \
+  --project="${PROJECT}" \
+  --zone="${ZONE}" \
+  --machine-type="${MACHINE_TYPE}" \
+  --image-family=debian-12 \
+  --image-project=debian-cloud \
+  --tags=yisbeta-vpn-relay \
+  --scopes=cloud-platform \
+  2>/dev/null || echo "VM already exists, continuing..."
+
+echo "==> [2/6] Opening firewall: allow Cloud Run VPC → port 1433 on this VM..."
+gcloud compute firewall-rules create allow-yisbeta-relay \
+  --project="${PROJECT}" \
+  --direction=INGRESS \
+  --action=ALLOW \
+  --rules=tcp:1433 \
+  --target-tags=yisbeta-vpn-relay \
+  --source-ranges=10.8.0.0/28,172.16.0.0/28 \
+  --description="Allow Cloud Run VPC connectors to reach VPN SQL relay port" \
+  2>/dev/null || echo "Firewall rule already exists, continuing."
+
+echo "==> [3/6] Getting VM internal IP..."
+sleep 5
+INTERNAL_IP=$(gcloud compute instances describe "${VM_NAME}" \
+  --project="${PROJECT}" \
+  --zone="${ZONE}" \
+  --format="get(networkInterfaces[0].networkIP)")
+echo "    Internal IP: ${INTERNAL_IP}"
+
+echo "==> [4/6] Installing Docker + pulling repo on VM..."
+gcloud compute ssh "${VM_NAME}" \
+  --project="${PROJECT}" \
+  --zone="${ZONE}" \
+  --command="
+    set -e
+    # Install Docker if not present
+    if ! command -v docker &>/dev/null; then
+      echo '[vm] Installing Docker...'
+      curl -fsSL https://get.docker.com | sh
+      sudo usermod -aG docker \$USER || true
+    fi
+
+    # Clone or update the repo
+    if [ -d '${REPO_DIR}' ]; then
+      echo '[vm] Pulling latest repo...'
+      cd '${REPO_DIR}' && sudo git pull
+    else
+      echo '[vm] Cloning repo...'
+      sudo git clone '${REPO_URL}' '${REPO_DIR}'
+    fi
+
+    echo '[vm] Building VPN Docker image...'
+    cd '${DOCKER_DIR}'
+    sudo docker build -t youngsinc-vpn-tunnel .
+    echo '[vm] Image built successfully.'
+  "
+
+echo "==> [5/6] Starting VPN tunnel container on VM..."
+
+# Build the env-var string based on VPN mode
+if [ "${VPN_MODE}" = "l2tp" ]; then
+  ENV_VARS="-e VPN_SERVER='${VPN_SERVER}' -e VPN_PSK='${VPN_PSK}' -e VPN_USER='${VPN_USER}' -e VPN_PASS='${VPN_PASS}' -e TARGET_HOST='${TARGET_HOST}' -e TARGET_PORT='${TARGET_PORT}'"
+else
+  ENV_VARS="-e VPN_SERVER='${VPN_SERVER}' -e VPN_PSK='${VPN_PSK}' -e TARGET_HOST='${TARGET_HOST}' -e TARGET_PORT='${TARGET_PORT}'"
+fi
+
+gcloud compute ssh "${VM_NAME}" \
+  --project="${PROJECT}" \
+  --zone="${ZONE}" \
+  --command="
+    set -e
+    # Stop existing container if running
+    sudo docker rm -f youngsinc-tunnel 2>/dev/null || true
+
+    echo '[vm] Starting VPN tunnel container...'
+    sudo docker run -d \
+      --name youngsinc-tunnel \
+      --restart=always \
+      --privileged \
+      --cap-add NET_ADMIN \
+      --cap-add SYS_MODULE \
+      -p 1433:1433 \
+      ${ENV_VARS} \
+      youngsinc-vpn-tunnel
+
+    echo '[vm] Waiting 30s for VPN to establish...'
+    sleep 30
+    echo '[vm] Container logs:'
+    sudo docker logs youngsinc-tunnel 2>&1 | tail -30
+
+    echo '[vm] Testing port 1433...'
+    if nc -z 127.0.0.1 1433 2>/dev/null; then
+      echo '[vm] ✅ Port 1433 is open — SQL Server reachable through VPN!'
+    else
+      echo '[vm] ⚠️  Port 1433 not responding — check logs: sudo docker logs youngsinc-tunnel'
+    fi
+  "
+
+echo ""
+echo "==> [6/6] Updating connections.json on your local machine..."
+# Print the connection block — user should add it to connections.json manually
+cat <<CONNBLOCK
+
+Add this entry to connections.json (replace <INTERNAL_IP> with ${INTERNAL_IP}):
+
+{
+  "alias": "yisbeta_relay_vm",
+  "label": "YIS Beta via Cloud VPN Relay VM",
+  "db_type": "mssql",
+  "host": "${INTERNAL_IP}",
+  "port": 1433,
+  "database": "YISBeta",
+  "user": "3vAnalysts2",
+  "password_secret": "projects/unicon-494419/secrets/yisbeta-db-password/versions/latest",
+  "instance_connection_name": "",
+  "allowed_tables": ""
+}
+
+Then update Cloud Run env var:
+  DB_DEFAULT_ALIAS=yisbeta_relay_vm
+
+CONNBLOCK
+
+echo "======================================================================"
+echo "  VPN Relay VM setup complete!"
+echo ""
+echo "  VM Name      : ${VM_NAME}"
+echo "  Internal IP  : ${INTERNAL_IP}   ← use as MSSQL_HOST in Cloud Run"
+echo "  SQL port     : 1433"
+echo "  VPN mode     : ${VPN_MODE}"
+echo ""
+echo "  Next steps:"
+echo "  1. Update connections.json with alias 'yisbeta_relay_vm' above"
+echo "  2. Run: gcloud run services update agentic-rag-chat \\"
+echo "            --region=us-central1 \\"
+echo "            --set-env-vars=DB_DEFAULT_ALIAS=yisbeta_relay_vm \\"
+echo "            --vpc-connector=ai-factory-connector \\"
+echo "            --vpc-egress=private-ranges-only"
+echo "  3. Test: send 'How many customers do we have?' to the agent"
+echo ""
+echo "  To check VPN status later:"
+echo "    gcloud compute ssh ${VM_NAME} --zone=${ZONE} \\"
+echo "      --command='sudo docker logs youngsinc-tunnel --tail=50'"
+echo "======================================================================"


### PR DESCRIPTION
Brings in the two doc-only additions from `cloud-env-setup-docs` without the older agent.py/pii_masking.py that would have been regressions:

- **CLOUD_ENV_SETUP.md** — was empty (0 bytes); now contains 280 lines of full GCP/VPN/Cloud Run reference
- **scripts/vpn_relay_vm/setup_vpn_relay_vm.sh** — new scrubbed VPN relay VM setup script (198 lines)

The `cloud-env-setup-docs` branch can be deleted after this merges.