### PR TITLE
fix: sidebar UI redesign, 500 error on support agent, CORS headers

### DIFF
--- a/run_local.py
+++ b/run_local.py
@@ -17,6 +17,7 @@ import threading
 
 import uvicorn
 from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from google.adk.cli.fast_api import get_fast_api_app
@@ -30,6 +31,14 @@ app: FastAPI = get_fast_api_app(
     agents_dir=_AGENTS_DIR,
     web=False,  # API-only mode (no ADK dev UI)
     allow_origins=["*"],
+)
+
+# Explicit CORS middleware so Authorization header is allowed on preflight
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # ── Firebase Auth Middleware ──────────────────────────────────────────────────

--- a/src/support_agent/agent.py
+++ b/src/support_agent/agent.py
@@ -372,7 +372,7 @@ def merge_pull_request(pr_number: int, merge_commit_message: str = "") -> dict:
 def create_github_issue(
     title: str,
     body: str,
-    labels: list[str] | None = None,
+    labels: str = "support/enhancement",
 ) -> dict:
     """Create a GitHub issue for enhancements or cases needing admin review.
 
@@ -380,9 +380,9 @@ def create_github_issue(
         title: Concise issue title
         body: Full description including the user's original complaint verbatim,
               your analysis, and recommended next steps
-        labels: Labels to apply (defaults to ['support/enhancement'])
+        labels: Comma-separated label names to apply (default: 'support/enhancement')
     """
-    issue_labels = labels or ["support/enhancement"]
+    issue_labels = [l.strip() for l in labels.split(",") if l.strip()] or ["support/enhancement"]
     result = _gh(
         "POST",
         f"/repos/{_REPO_OWNER}/{_REPO_NAME}/issues",

--- a/ui/app.js
+++ b/ui/app.js
@@ -619,23 +619,33 @@ el.apiBase.addEventListener('change', () => {
   });
 })();
 
-/* ── Tab Navigation ──────────────────────────────────────── */
+/* ── Sidebar Navigation ─────────────────────────────────── */
 (function initTabs() {
-  const tabBtns   = document.querySelectorAll('.tab-btn');
+  const navItems  = document.querySelectorAll('.sidebar-nav-item');
   const tabViews  = document.querySelectorAll('.tab-view');
-  const dbBar     = document.querySelector('.topbar-db');
   const settPanel = document.getElementById('settingsPanel');
 
-  tabBtns.forEach((btn) => {
+  navItems.forEach((btn) => {
     btn.addEventListener('click', () => {
       const tab = btn.dataset.tab;
-      tabBtns.forEach((b) => b.classList.toggle('active', b.dataset.tab === tab));
+      navItems.forEach((b) => b.classList.toggle('active', b.dataset.tab === tab));
       tabViews.forEach((v) => v.classList.toggle('active', v.id === `view-${tab}`));
-      if (dbBar)    dbBar.style.display = tab === 'rag' ? '' : 'none';
       if (settPanel && tab !== 'rag') settPanel.classList.remove('open');
       window.dispatchEvent(new CustomEvent('tab-changed', { detail: { tab } }));
     });
   });
+
+  // Sidebar collapse toggle
+  const sidebar   = document.getElementById('sidebar');
+  const collapseBtn = document.getElementById('sidebarCollapseBtn');
+  if (sidebar && collapseBtn) {
+    const saved = localStorage.getItem('sidebarCollapsed') === 'true';
+    if (saved) sidebar.classList.add('collapsed');
+    collapseBtn.addEventListener('click', () => {
+      sidebar.classList.toggle('collapsed');
+      localStorage.setItem('sidebarCollapsed', sidebar.classList.contains('collapsed'));
+    });
+  }
 })();
 
 /* ── Settings Panel Toggle ─────────────────────────────── */

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Agentic RAG Chat</title>
+  <title>Agentic RAG</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -16,123 +16,161 @@
 </head>
 <body>
 
-<!-- AUTH OVERLAY — shown until user signs in -->
+<!-- AUTH OVERLAY -->
 <div id="authOverlay" class="auth-overlay">
   <div class="auth-card">
-    <div class="auth-logo">✦</div>
+    <div class="auth-logo">&#10022;</div>
     <div class="auth-title">Agentic RAG</div>
-    <p class="auth-subtitle">Powered by Gemini &amp; Google ADK</p>
+    <p class="auth-subtitle">Intelligent data access system</p>
     <button id="signInBtn" class="auth-sign-in-btn">
       <span class="google-g">G</span>Sign in with Google
     </button>
   </div>
 </div>
 
+<!-- APP SHELL: sidebar + main -->
 <div class="app-shell" id="appShell" style="display:none">
 
-  <!-- HEADER -->
-  <header class="app-header">
-    <div class="header-left">
-      <button id="settingsToggle" class="icon-btn" title="Settings" aria-label="Toggle settings">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <circle cx="12" cy="12" r="3"/>
-          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+  <!-- SIDEBAR -->
+  <aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+      <div class="sidebar-brand">
+        <span class="sidebar-logo">&#10022;</span>
+        <span class="sidebar-name">Agentic RAG</span>
+      </div>
+      <button id="sidebarCollapseBtn" class="icon-btn sidebar-collapse-btn" title="Collapse sidebar" aria-label="Collapse sidebar">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="15 18 9 12 15 6"/>
         </svg>
       </button>
-      <span class="app-title">Agentic RAG</span>
-      <!-- Tab Navigation -->
-      <nav class="tab-nav" aria-label="App sections">
-        <button class="tab-btn active" data-tab="rag" aria-label="RAG Chat">Chat</button>
-        <button class="tab-btn" data-tab="support" aria-label="Support">🛠 Support</button>
-      </nav>
     </div>
-    <div class="header-right">
-      <div class="topbar-db">
-        <span class="db-dot"></span>
-        <label class="db-label" for="dbAlias">DB</label>
-        <select id="dbAlias" class="topbar-db-select">
-          <option value="">– select –</option>
-        </select>
-        <div id="dbBadge" class="db-badge" style="display:none"></div>
-      </div>
-      <!-- User pill (hidden until signed in) -->
-      <div id="userPill" class="user-pill" style="display:none">
+
+    <nav class="sidebar-nav" aria-label="App sections">
+      <button class="sidebar-nav-item active" data-tab="rag">
+        <svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+        </svg>
+        <span class="nav-label">Chat</span>
+      </button>
+      <button class="sidebar-nav-item" data-tab="support">
+        <svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+        </svg>
+        <span class="nav-label">Support</span>
+      </button>
+    </nav>
+
+    <div class="sidebar-spacer"></div>
+
+    <!-- DB Selector -->
+    <div class="sidebar-db topbar-db">
+      <span class="db-dot"></span>
+      <label class="db-label" for="dbAlias">DB</label>
+      <select id="dbAlias" class="topbar-db-select">
+        <option value="">&ndash; select &ndash;</option>
+      </select>
+      <div id="dbBadge" class="db-badge" style="display:none"></div>
+    </div>
+
+    <!-- Footer: user + controls -->
+    <div class="sidebar-footer">
+      <div id="userPill" class="sidebar-user" style="display:none">
         <span id="userAvatar" class="user-avatar">U</span>
-        <span id="userEmail" class="user-email"></span>
-        <span id="adminBadge" class="admin-badge" style="display:none">Admin</span>
-        <button id="signOutBtn" class="sign-out-btn" title="Sign out" aria-label="Sign out">↪</button>
+        <div class="sidebar-user-text">
+          <span id="userEmail" class="user-email"></span>
+          <span id="adminBadge" class="admin-badge" style="display:none">Admin</span>
+        </div>
+        <button id="signOutBtn" class="sign-out-btn" title="Sign out" aria-label="Sign out">&#x21aa;</button>
       </div>
-      <button id="themeToggle" class="icon-btn theme-btn" title="Toggle theme" aria-label="Toggle theme">🌙</button>
-    </div>
-  </header>
-
-  <!-- SETTINGS PANEL (collapsed by default) -->
-  <div id="settingsPanel" class="settings-panel">
-    <div class="settings-inner">
-      <div class="settings-grid">
-        <label>
-          <span>API Base URL</span>
-          <input id="apiBase" type="url" placeholder="https://… (blank = same origin)" autocomplete="off" spellcheck="false" />
-        </label>
-        <label>
-          <span>App Name</span>
-          <input id="appName" type="text" placeholder="agentic_rag" />
-        </label>
-        <label>
-          <span>User ID</span>
-          <input id="userId" type="text" placeholder="web-user" />
-        </label>
-        <label>
-          <span>Session ID</span>
-          <input id="sessionId" type="text" readonly placeholder="(auto-assigned)" />
-        </label>
-      </div>
-      <div class="settings-actions">
-        <button id="newSessionBtn" type="button">New Session</button>
-        <button id="clearChatBtn" type="button" class="secondary">Clear Chat</button>
+      <div class="sidebar-footer-actions">
+        <button id="themeToggle" class="icon-btn theme-btn" title="Toggle theme" aria-label="Toggle theme">&#x1F319;</button>
       </div>
     </div>
-  </div>
+  </aside>
 
-  <!-- RAG CHAT VIEW -->
-  <div id="view-rag" class="tab-view active">
-    <main id="chat" class="chat-area" aria-live="polite"></main>
-    <div class="composer">
-      <form id="chatForm" class="composer-form" autocomplete="off">
-        <textarea id="prompt" class="composer-input" rows="1"
-          placeholder="Ask a question… (Enter to send · Shift+Enter for new line)"></textarea>
-        <button id="sendBtn" type="submit" class="send-btn" aria-label="Send">
-          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="22" y1="2" x2="11" y2="13"/>
-            <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+  <!-- MAIN CONTENT -->
+  <div class="main-content">
+
+    <!-- SETTINGS PANEL (collapsed by default) -->
+    <div id="settingsPanel" class="settings-panel">
+      <div class="settings-inner">
+        <div class="settings-grid">
+          <label>
+            <span>API Base URL</span>
+            <input id="apiBase" type="url" placeholder="https://&hellip; (blank = same origin)" autocomplete="off" spellcheck="false" />
+          </label>
+          <label>
+            <span>App Name</span>
+            <input id="appName" type="text" placeholder="agentic_rag" />
+          </label>
+          <label>
+            <span>User ID</span>
+            <input id="userId" type="text" placeholder="web-user" />
+          </label>
+          <label>
+            <span>Session ID</span>
+            <input id="sessionId" type="text" readonly placeholder="(auto-assigned)" />
+          </label>
+        </div>
+        <div class="settings-actions">
+          <button id="newSessionBtn" type="button">New Session</button>
+          <button id="clearChatBtn" type="button" class="secondary">Clear Chat</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- RAG CHAT VIEW -->
+    <div id="view-rag" class="tab-view active">
+      <div class="view-header">
+        <span class="view-title">Chat</span>
+        <button id="settingsToggle" class="icon-btn" title="Settings" aria-label="Toggle settings">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="3"/>
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
           </svg>
         </button>
-      </form>
+      </div>
+      <main id="chat" class="chat-area" aria-live="polite"></main>
+      <div class="composer">
+        <form id="chatForm" class="composer-form" autocomplete="off">
+          <textarea id="prompt" class="composer-input" rows="1"
+            placeholder="Ask a question&hellip; (Enter to send &middot; Shift+Enter for new line)"></textarea>
+          <button id="sendBtn" type="submit" class="send-btn" aria-label="Send">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="22" y1="2" x2="11" y2="13"/>
+              <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+            </svg>
+          </button>
+        </form>
+      </div>
     </div>
-  </div>
 
-  <!-- SUPPORT VIEW -->
-  <div id="view-support" class="tab-view">
-    <div class="support-intro">
-      <p>Describe an issue you're experiencing and the Support Agent will investigate the code,
-      open a fix PR, and deploy it if the root cause is confirmed.</p>
+    <!-- SUPPORT VIEW -->
+    <div id="view-support" class="tab-view">
+      <div class="view-header">
+        <span class="view-title">Support</span>
+      </div>
+      <div class="support-intro">
+        <p>Describe an issue you're experiencing and the Support Agent will investigate the code, open a fix PR, and deploy it if the root cause is confirmed.</p>
+      </div>
+      <main id="support-chat" class="chat-area" aria-live="polite"></main>
+      <div class="composer">
+        <form id="supportForm" class="composer-form" autocomplete="off">
+          <textarea id="support-prompt" class="composer-input" rows="1"
+            placeholder="Describe your issue&hellip; (Enter to send &middot; Shift+Enter for new line)"></textarea>
+          <button id="supportSendBtn" type="submit" class="send-btn" aria-label="Send">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="22" y1="2" x2="11" y2="13"/>
+              <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+            </svg>
+          </button>
+        </form>
+      </div>
     </div>
-    <main id="support-chat" class="chat-area" aria-live="polite"></main>
-    <div class="composer">
-      <form id="supportForm" class="composer-form" autocomplete="off">
-        <textarea id="support-prompt" class="composer-input" rows="1"
-          placeholder="Describe your issue… (Enter to send · Shift+Enter for new line)"></textarea>
-        <button id="supportSendBtn" type="submit" class="send-btn" aria-label="Send">
-          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="22" y1="2" x2="11" y2="13"/>
-            <polygon points="22 2 15 22 11 13 2 9 22 2"/>
-          </svg>
-        </button>
-      </form>
-    </div>
-  </div><!-- /.tab-view #view-support -->
 
-</div><!-- /.app-shell #appShell -->
+  </div><!-- /.main-content -->
+
+</div><!-- /.app-shell -->
 
 <template id="msgTemplate">
   <article class="msg">

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -83,45 +83,215 @@ body {
 /* ---- App shell -------------------------------------------- */
 .app-shell {
   display: flex;
-  flex-direction: column;
-  height: 100vh;          /* fallback */
+  flex-direction: row;
+  height: 100vh;
   height: 100dvh;
-  max-width: 900px;
-  margin: 0 auto;
+  overflow: hidden;
 }
 
-/* ---- Header ----------------------------------------------- */
-.app-header {
+/* ---- Main content area ------------------------------------ */
+.main-content {
+  flex: 1 1 0;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  min-width: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ---- Sidebar ---------------------------------------------- */
+.sidebar {
+  width: 260px;
+  min-width: 260px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  transition: width var(--dur) ease, min-width var(--dur) ease,
+              background var(--dur) ease, border-color var(--dur) ease;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.sidebar.collapsed {
+  width: 60px;
+  min-width: 60px;
+}
+
+.sidebar-header {
+  display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 56px;
-  min-height: 56px;
-  padding: 0 16px;
+  padding: 16px 14px 12px;
   flex-shrink: 0;
-  background: var(--header-bg);
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  overflow: hidden;
+}
+
+.sidebar-logo {
+  font-size: 1.2rem;
+  color: var(--accent);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.sidebar-name {
+  font-size: 0.97rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  transition: opacity var(--dur) ease, max-width var(--dur) ease;
+}
+
+.sidebar.collapsed .sidebar-name { opacity: 0; max-width: 0; }
+
+.sidebar-collapse-btn {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: var(--xmuted);
+  transition: transform var(--dur) ease, color var(--dur) ease;
+}
+.sidebar-collapse-btn:hover { color: var(--text); border-color: transparent; }
+.sidebar.collapsed .sidebar-collapse-btn { transform: rotate(180deg); }
+
+/* ---- Sidebar navigation ----------------------------------- */
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 4px 10px;
+  flex-shrink: 0;
+}
+
+.sidebar-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--dur) ease, color var(--dur) ease;
+  white-space: nowrap;
+}
+
+.sidebar-nav-item:hover:not(.active) {
+  background: var(--surface2);
+  color: var(--text);
+  border-color: transparent;
+}
+
+.sidebar-nav-item.active {
+  background: rgba(37,99,235,0.1);
+  color: var(--accent);
+  border-color: transparent;
+}
+
+[data-theme="dark"] .sidebar-nav-item.active {
+  background: rgba(59,130,246,0.15);
+  color: var(--accent-h);
+}
+
+.nav-icon {
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+.sidebar-nav-item.active .nav-icon { opacity: 1; }
+
+.nav-label {
+  overflow: hidden;
+  transition: opacity var(--dur) ease, max-width var(--dur) ease;
+}
+.sidebar.collapsed .nav-label { opacity: 0; max-width: 0; }
+
+/* ---- Sidebar spacer --------------------------------------- */
+.sidebar-spacer { flex: 1 1 0; }
+
+/* ---- Sidebar DB selector ---------------------------------- */
+.sidebar-db {
+  margin: 0 10px 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.sidebar.collapsed .sidebar-db { display: none; }
+
+/* ---- Sidebar footer --------------------------------------- */
+.sidebar-footer {
+  border-top: 1px solid var(--border);
+  padding: 10px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color var(--dur) ease;
+}
+
+.sidebar-user {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px;
+  border-radius: 10px;
+  background: var(--surface2);
+  transition: background var(--dur) ease;
+  overflow: hidden;
+}
+
+.sidebar-user:hover { background: var(--bg); }
+
+.sidebar-user-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+
+.sidebar.collapsed .sidebar-user-text { display: none; }
+.sidebar.collapsed .sign-out-btn { display: none; }
+
+.sidebar-footer-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* ---- View header (inside main-content) -------------------- */
+.view-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 52px;
+  min-height: 52px;
+  padding: 0 20px;
+  flex-shrink: 0;
   border-bottom: 1px solid var(--border);
-  position: sticky;
-  top: 0;
-  z-index: 20;
+  background: var(--header-bg);
   transition: background var(--dur) ease, border-color var(--dur) ease;
 }
 
-.header-left,
-.header-right {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 10px;
-}
-
-.app-title {
-  font-size: 1rem;
+.view-title {
+  font-size: 0.95rem;
   font-weight: 600;
   color: var(--text);
   letter-spacing: -0.01em;
-  white-space: nowrap;
 }
 
 /* ---- Icon buttons ----------------------------------------- */
@@ -939,36 +1109,19 @@ code.sql-display {
 }
 
 /* ============================================================
-   Tab Navigation
+   Mobile sidebar toggle
    ============================================================ */
-.tab-nav {
-  display: flex;
-  gap: 4px;
-  margin-left: 12px;
-}
-
-.tab-btn {
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--muted);
-  border-radius: 8px;
-  padding: 5px 13px;
-  font-size: 0.84rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background var(--dur) ease, color var(--dur) ease, border-color var(--dur) ease;
-}
-
-.tab-btn:hover:not(.active) {
-  background: var(--surface2);
-  color: var(--text);
-  border-color: var(--border);
-}
-
-.tab-btn.active {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
+@media (max-width: 640px) {
+  .sidebar {
+    position: fixed;
+    left: 0; top: 0; bottom: 0;
+    z-index: 100;
+    transform: translateX(0);
+    box-shadow: 4px 0 16px rgba(0,0,0,0.15);
+    transition: transform var(--dur) ease;
+  }
+  .sidebar.mobile-hidden { transform: translateX(-100%); }
+  .main-content { width: 100%; }
 }
 
 /* ============================================================
@@ -987,30 +1140,18 @@ code.sql-display {
 }
 
 /* ============================================================
-   User Pill
+   User elements (sidebar footer)
    ============================================================ */
-.user-pill {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px 4px 6px;
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  background: var(--surface);
-  font-size: 0.82rem;
-  transition: background var(--dur) ease;
-}
-
 .user-avatar {
-  width: 24px;
-  height: 24px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background: var(--accent);
   color: #fff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   font-weight: 700;
   flex-shrink: 0;
 }
@@ -1018,14 +1159,13 @@ code.sql-display {
 .user-email {
   font-size: 0.78rem;
   color: var(--muted);
-  max-width: 140px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .admin-badge {
-  font-size: 0.65rem;
+  font-size: 0.62rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -1033,23 +1173,26 @@ code.sql-display {
   color: #fff;
   padding: 1px 6px;
   border-radius: 10px;
+  width: fit-content;
 }
 
 .sign-out-btn {
+  flex-shrink: 0;
   border: none;
   background: transparent;
   color: var(--xmuted);
-  padding: 2px 4px;
+  padding: 3px 5px;
   cursor: pointer;
-  font-size: 0.88rem;
+  font-size: 0.9rem;
   line-height: 1;
-  border-radius: 4px;
+  border-radius: 6px;
   transition: color var(--dur) ease, background var(--dur) ease;
+  margin-left: auto;
 }
 
 .sign-out-btn:hover {
   color: var(--text);
-  background: var(--surface2);
+  background: var(--border);
   border-color: transparent;
 }
 
@@ -1074,8 +1217,7 @@ code.sql-display {
    Responsive adjustments
    ============================================================ */
 @media (max-width: 480px) {
-  .tab-nav      { margin-left: 6px; }
-  .tab-btn      { padding: 4px 9px; font-size: 0.78rem; }
-  .user-email   { display: none; }
   .auth-card    { padding: 36px 24px; }
+  .view-header  { padding: 0 12px; }
+  .composer     { padding: 8px 10px 12px; }
 }


### PR DESCRIPTION
## Fixes

### 1. 500 Internal Server Error on support agent
ADK cannot auto-parse `list[str] | None` union types in tool function signatures. Changed `create_github_issue` `labels` parameter from `list[str] | None = None` to `str = "support/enhancement"` with comma-split inside the function.

### 2. CORS errors
Added explicit `CORSMiddleware` with `allow_headers=["*"]` so the `Authorization` Bearer token header is allowed on cross-origin preflight requests.

### 3. ChatGPT-like sidebar UI
- Left sidebar (260px) with Chat + Support navigation items
- Collapsible sidebar with state persistence in localStorage
- DB selector and user profile moved to sidebar footer
- Clean `view-header` bar inside each tab view
- Removed top header bar — more screen space for chat

### 4. Login page text
Changed "Powered by Gemini & Google ADK" → "Intelligent data access system"